### PR TITLE
feat: add user profiles table and CRUD methods

### DIFF
--- a/cli/storage.py
+++ b/cli/storage.py
@@ -1,0 +1,296 @@
+"""SQLite local storage for jobs, regions, and config."""
+
+import json
+import sqlite3
+import time
+
+
+class Storage:
+    def __init__(self, db_path: str):
+        self._conn = sqlite3.connect(db_path)
+        self._conn.row_factory = sqlite3.Row
+
+    def init_db(self):
+        cur = self._conn.cursor()
+        cur.executescript("""
+            CREATE TABLE IF NOT EXISTS jobs (
+                event_id TEXT PRIMARY KEY,
+                d_tag TEXT UNIQUE,
+                pubkey TEXT NOT NULL,
+                province_code INTEGER,
+                city_code INTEGER,
+                content TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                received_at INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS regions (
+                code INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL,
+                parent_code INTEGER
+            );
+            CREATE TABLE IF NOT EXISTS config (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS job_status (
+                event_id TEXT PRIMARY KEY,
+                favorited INTEGER DEFAULT 0,
+                applied INTEGER DEFAULT 0,
+                created_at INTEGER DEFAULT (unixepoch('now')),
+                updated_at INTEGER DEFAULT (unixepoch('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_job_status_event_id ON job_status(event_id);
+            CREATE TABLE IF NOT EXISTS profiles (
+                pubkey TEXT PRIMARY KEY,
+                event_id TEXT UNIQUE,
+                d_tag TEXT UNIQUE,
+                content TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                received_at INTEGER NOT NULL DEFAULT 0
+            );
+        """)
+        self._conn.commit()
+
+    def close(self):
+        self._conn.close()
+
+    def list_tables(self) -> list[str]:
+        cur = self._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+        return [row["name"] for row in cur.fetchall()]
+
+    # ── Config ──
+
+    def set_config(self, key: str, value: str):
+        self._conn.execute(
+            "INSERT OR REPLACE INTO config (key, value) VALUES (?, ?)",
+            (key, value),
+        )
+        self._conn.commit()
+
+    def get_config(self, key: str, default: str | None = None) -> str | None:
+        row = self._conn.execute(
+            "SELECT value FROM config WHERE key = ?", (key,)
+        ).fetchone()
+        return row["value"] if row else default
+
+    # ── Jobs ──
+
+    def upsert_job(
+        self,
+        event_id: str,
+        d_tag: str,
+        pubkey: str,
+        province_code: int,
+        city_code: int,
+        content: str,
+        created_at: int,
+    ):
+        # Delete existing job with same d_tag (replaceable event)
+        self._conn.execute("DELETE FROM jobs WHERE d_tag = ?", (d_tag,))
+        self._conn.execute(
+            """INSERT INTO jobs
+               (event_id, d_tag, pubkey, province_code, city_code, content, created_at, received_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (event_id, d_tag, pubkey, province_code, city_code, content, created_at, int(time.time())),
+        )
+        self._conn.commit()
+
+    def get_job(self, event_id: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT * FROM jobs WHERE event_id = ?", (event_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    def count_jobs(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) as cnt FROM jobs").fetchone()
+        return row["cnt"]
+
+    def evict_oldest(self, max_count: int):
+        count = self.count_jobs()
+        if count <= max_count:
+            return
+        to_delete = count - max_count
+        self._conn.execute(
+            "DELETE FROM jobs WHERE event_id IN "
+            "(SELECT event_id FROM jobs ORDER BY created_at ASC LIMIT ?)",
+            (to_delete,),
+        )
+        self._conn.commit()
+
+    # ── Regions ──
+
+    def upsert_region(
+        self,
+        code: int,
+        name: str,
+        region_type: str,
+        parent_code: int | None = None,
+    ):
+        self._conn.execute(
+            "INSERT OR REPLACE INTO regions (code, name, type, parent_code) VALUES (?, ?, ?, ?)",
+            (code, name, region_type, parent_code),
+        )
+        self._conn.commit()
+
+    def get_region(self, code: int) -> dict | None:
+        row = self._conn.execute(
+            "SELECT * FROM regions WHERE code = ?", (code,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    def list_regions(self, region_type: str | None = None) -> list[dict]:
+        if region_type:
+            rows = self._conn.execute(
+                "SELECT * FROM regions WHERE type = ? ORDER BY code", (region_type,)
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM regions ORDER BY code"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    # ── Job Status ──
+
+    def upsert_status(self, event_id: str, favorited: bool | None = None, applied: bool | None = None):
+        """Set or toggle status for a job. If status already exists, flips the value."""
+        existing = self.get_status(event_id)
+        current_fav = existing["favorited"] if existing else 0
+        current_app = existing["applied"] if existing else 0
+        # Toggle if favorited is True, keep current if favorited is False (explicit set)
+        new_fav = (1 - current_fav) if favorited is True else (0 if favorited is False else current_fav)
+        new_app = (1 - current_app) if applied is True else (0 if applied is False else current_app)
+        self._conn.execute(
+            """INSERT OR REPLACE INTO job_status (event_id, favorited, applied, updated_at)
+               VALUES (?, ?, ?, unixepoch('now'))""",
+            (event_id, new_fav, new_app),
+        )
+        self._conn.commit()
+
+    def get_status(self, event_id: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT * FROM job_status WHERE event_id = ?", (event_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    # ── Job Search ──
+
+    def _escape_like(self, text: str) -> str:
+        """Escape special characters in LIKE pattern."""
+        return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    def search_jobs(self, query: str) -> list[dict]:
+        """Search jobs by keywords in title, company, and description.
+
+        Case-insensitive AND matching: all keywords must match.
+        Empty query returns all jobs.
+        Uses json_extract to search specific fields (no substring false positives).
+        """
+        if not query or not query.strip():
+            rows = self._conn.execute(
+                "SELECT * FROM jobs ORDER BY created_at DESC"
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+        keywords = query.strip().split()
+        # Build WHERE clause for AND matching all keywords
+        conditions = []
+        params = []
+        for keyword in keywords:
+            escaped = self._escape_like(keyword)
+            pattern = f"%{escaped}%"
+            # Search in title, company, description using json_extract
+            conditions.append(
+                "(LOWER(json_extract(content, '$.title')) LIKE ? ESCAPE '\\' COLLATE NOCASE"
+                " OR LOWER(json_extract(content, '$.company')) LIKE ? ESCAPE '\\' COLLATE NOCASE"
+                " OR LOWER(json_extract(content, '$.description')) LIKE ? ESCAPE '\\' COLLATE NOCASE)"
+            )
+            params.extend([pattern, pattern, pattern])
+
+        where_clause = " AND ".join(conditions)
+        sql = f"SELECT * FROM jobs WHERE {where_clause} ORDER BY created_at DESC"
+        rows = self._conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+    def list_jobs(
+        self,
+        province_code: int | None = None,
+        city_code: int | None = None,
+        favorited: bool | None = None,
+        applied: bool | None = None,
+        search_query: str | None = None,
+    ) -> list[dict]:
+        query = "SELECT jobs.* FROM jobs LEFT JOIN job_status ON jobs.event_id = job_status.event_id WHERE 1=1"
+        params: list = []
+        if province_code is not None:
+            query += " AND jobs.province_code = ?"
+            params.append(province_code)
+        if city_code is not None:
+            query += " AND jobs.city_code = ?"
+            params.append(city_code)
+        if favorited is not None:
+            query += " AND job_status.favorited = ?"
+            params.append(1 if favorited else 0)
+        if applied is not None:
+            query += " AND job_status.applied = ?"
+            params.append(1 if applied else 0)
+        if search_query and search_query.strip():
+            keywords = search_query.strip().split()
+            for keyword in keywords:
+                escaped = self._escape_like(keyword)
+                pattern = f"%{escaped}%"
+                query += (
+                    " AND (LOWER(json_extract(jobs.content, '$.title')) LIKE ? ESCAPE '\\' COLLATE NOCASE"
+                    " OR LOWER(json_extract(jobs.content, '$.company')) LIKE ? ESCAPE '\\' COLLATE NOCASE"
+                    " OR LOWER(json_extract(jobs.content, '$.description')) LIKE ? ESCAPE '\\' COLLATE NOCASE)"
+                )
+                params.extend([pattern, pattern, pattern])
+        query += " ORDER BY jobs.created_at DESC"
+        rows = self._conn.execute(query, params).fetchall()
+        return [dict(r) for r in rows]
+
+    # ── Profiles ──
+
+    def upsert_profile(
+        self,
+        pubkey: str,
+        event_id: str,
+        d_tag: str,
+        content: str,
+        created_at: int,
+    ):
+        """Store or update a user profile."""
+        self._conn.execute(
+            """INSERT OR REPLACE INTO profiles
+               (pubkey, event_id, d_tag, content, created_at, received_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (pubkey, event_id, d_tag, content, created_at, int(time.time())),
+        )
+        self._conn.commit()
+
+    def get_profile(self, pubkey: str) -> dict | None:
+        """Get profile by pubkey."""
+        row = self._conn.execute(
+            "SELECT * FROM profiles WHERE pubkey = ?", (pubkey,)
+        ).fetchone()
+        if not row:
+            return None
+        profile = dict(row)
+        # Parse JSON content to extract name for convenience
+        try:
+            content = json.loads(profile.get("content", "{}"))
+            profile["name"] = content.get("name", "")
+        except (json.JSONDecodeError, TypeError):
+            profile["name"] = ""
+        return profile
+
+    def get_own_profile(self, pubkey: str) -> dict | None:
+        """Alias for get_profile."""
+        return self.get_profile(pubkey)
+
+    def delete_profile(self, pubkey: str):
+        """Delete profile by pubkey."""
+        self._conn.execute("DELETE FROM profiles WHERE pubkey = ?", (pubkey,))
+        self._conn.commit()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,355 @@
+import os
+import pytest
+import sqlite3
+from cli.storage import Storage
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    s = Storage(db_path)
+    s.init_db()
+    yield s
+    s.close()
+
+
+class TestStorageInit:
+    def test_creates_tables(self, db):
+        tables = db.list_tables()
+        assert "jobs" in tables
+        assert "regions" in tables
+        assert "config" in tables
+
+
+class TestConfig:
+    def test_set_and_get(self, db):
+        db.set_config("relay", "ws://localhost:7777")
+        assert db.get_config("relay") == "ws://localhost:7777"
+
+    def test_get_missing_returns_default(self, db):
+        assert db.get_config("missing", "default") == "default"
+
+    def test_set_overwrites(self, db):
+        db.set_config("key", "v1")
+        db.set_config("key", "v2")
+        assert db.get_config("key") == "v2"
+
+
+class TestJobs:
+    def test_upsert_and_get(self, db):
+        db.upsert_job(
+            event_id="id1",
+            d_tag="d1",
+            pubkey="pub1",
+            province_code=1,
+            city_code=101,
+            content='{"title":"Dev"}',
+            created_at=1000,
+        )
+        job = db.get_job("id1")
+        assert job is not None
+        assert job["d_tag"] == "d1"
+        assert job["province_code"] == 1
+
+    def test_upsert_replaces_by_d_tag(self, db):
+        db.upsert_job("id1", "d1", "pub1", 1, 101, '{"v":1}', 1000)
+        db.upsert_job("id2", "d1", "pub1", 1, 101, '{"v":2}', 2000)
+        # old id1 should be gone, id2 should exist
+        assert db.get_job("id1") is None
+        assert db.get_job("id2") is not None
+
+    def test_list_jobs_filter_province(self, db):
+        db.upsert_job("id1", "d1", "p", 1, 101, "{}", 1000)
+        db.upsert_job("id2", "d2", "p", 2, 201, "{}", 1000)
+        jobs = db.list_jobs(province_code=1)
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "id1"
+
+    def test_list_jobs_filter_city(self, db):
+        db.upsert_job("id1", "d1", "p", 1, 101, "{}", 1000)
+        db.upsert_job("id2", "d2", "p", 1, 102, "{}", 1000)
+        jobs = db.list_jobs(city_code=102)
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "id2"
+
+    def test_evict_oldest_when_over_limit(self, db):
+        for i in range(5):
+            db.upsert_job(f"id{i}", f"d{i}", "p", 1, 101, "{}", created_at=i)
+        db.evict_oldest(max_count=3)
+        remaining = db.list_jobs()
+        assert len(remaining) == 3
+        # oldest (created_at=0,1) should be evicted
+        ids = [j["event_id"] for j in remaining]
+        assert "id0" not in ids
+        assert "id1" not in ids
+
+    def test_count_jobs(self, db):
+        db.upsert_job("id1", "d1", "p", 1, 101, "{}", 1000)
+        db.upsert_job("id2", "d2", "p", 1, 101, "{}", 1000)
+        assert db.count_jobs() == 2
+
+
+class TestRegions:
+    def test_upsert_and_get_region(self, db):
+        db.upsert_region(code=1, name="北京", region_type="province")
+        r = db.get_region(1)
+        assert r["name"] == "北京"
+        assert r["type"] == "province"
+
+    def test_upsert_city_with_parent(self, db):
+        db.upsert_region(1, "北京", "province")
+        db.upsert_region(101, "北京市", "city", parent_code=1)
+        r = db.get_region(101)
+        assert r["parent_code"] == 1
+
+    def test_list_provinces(self, db):
+        db.upsert_region(1, "北京", "province")
+        db.upsert_region(2, "上海", "province")
+        db.upsert_region(101, "北京市", "city", parent_code=1)
+        provinces = db.list_regions(region_type="province")
+        assert len(provinces) == 2
+
+    def test_get_region_version(self, db):
+        """Region version stored in config"""
+        assert db.get_config("region_version", "0") == "0"
+        db.set_config("region_version", "3")
+        assert db.get_config("region_version") == "3"
+
+
+class TestJobSearch:
+    def test_search_single_keyword_title(self, db):
+        """Search finds job by keyword in title"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"React Developer","company":"TechCo","description":"Frontend work"}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"Python Backend","company":"DataCorp","description":"API development"}', 1000)
+        jobs = db.search_jobs("React")
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+    def test_search_single_keyword_company(self, db):
+        """Search finds job by keyword in company"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"Dev","company":"Google","description":"Work here"}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"Dev","company":"Meta","description":"Work here"}', 1000)
+        jobs = db.search_jobs("Google")
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+    def test_search_single_keyword_description(self, db):
+        """Search finds job by keyword in description"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"Dev","company":"Co","description":"Remote work available"}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"Dev","company":"Co","description":"Onsite only"}', 1000)
+        jobs = db.search_jobs("Remote")
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+    def test_search_multiple_keywords_and(self, db):
+        """Multiple keywords must all match (AND logic)"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"React Developer","company":"TechCo","description":"Frontend"}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"React Developer","company":"BigCorp","description":"Backend"}', 1000)
+        db.upsert_job("j3", "d3", "pub1", 1, 101, '{"title":"Python Dev","company":"TechCo","description":"Fullstack"}', 1000)
+        # Both "React" AND "Frontend" must match
+        jobs = db.search_jobs("React Frontend")
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+    def test_search_case_insensitive(self, db):
+        """Search is case-insensitive"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"React Developer","company":"TechCo","description":""}', 1000)
+        jobs_lower = db.search_jobs("react")
+        jobs_upper = db.search_jobs("REACT")
+        jobs_mixed = db.search_jobs("ReAcT")
+        assert len(jobs_lower) == 1
+        assert len(jobs_upper) == 1
+        assert len(jobs_mixed) == 1
+        assert jobs_lower[0]["event_id"] == "j1"
+
+    def test_search_no_match(self, db):
+        """Search returns empty when no job matches"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"React Developer","company":"TechCo","description":""}', 1000)
+        jobs = db.search_jobs("Python")
+        assert len(jobs) == 0
+
+    def test_search_empty_query(self, db):
+        """Search with empty query returns all jobs"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"Dev1","company":"C","description":""}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"Dev2","company":"C","description":""}', 1000)
+        jobs = db.search_jobs("")
+        assert len(jobs) == 2
+
+    def test_search_combined_with_filters(self, db):
+        """Search can be combined with province/city filters"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"React Dev","company":"Co","description":""}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 2, 201, '{"title":"React Dev","company":"Co","description":""}', 1000)
+        # Search for React, filtered by province 1
+        jobs = db.list_jobs(search_query="React", province_code=1)
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+    def test_search_returns_relevant_jobs_only(self, db):
+        """Search only searches in title, company, description of job content"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"Dev","company":"Acme","description":"Keywords: golang rust"}', 1000)
+        # "golang" is in description, "python" is not - should not match both (AND logic)
+        jobs = db.search_jobs("golang python")
+        assert len(jobs) == 0
+
+    def test_list_jobs_with_search_query(self, db):
+        """list_jobs accepts search_query parameter"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"Senior React Dev","company":"BigTech","description":"Build UI"}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"Python Backend","company":"DataCo","description":"API work"}', 1000)
+        jobs = db.list_jobs(search_query="React")
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+    def test_search_word_boundary_uses_json_extract(self, db):
+        """Search uses json_extract to match specific JSON fields, not raw JSON substring"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"React Developer","company":"TechCo","description":"Frontend work"}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"Python Dev","company":"Contact Co","description":"Customer support"}', 1000)
+        # "Contact" appears in j2's company field
+        # json_extract ensures we match the actual field values
+        jobs = db.search_jobs("Contact")
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j2"
+
+    def test_search_special_chars_escaped(self, db):
+        """Search correctly handles LIKE special characters (%)"""
+        db.upsert_job("j1", "d1", "pub1", 1, 101, '{"title":"100% Remote","company":"Co","description":"Work from anywhere"}', 1000)
+        db.upsert_job("j2", "d2", "pub1", 1, 101, '{"title":"Onsite Only","company":"Co","description":"No remote"}', 1000)
+        # "100%" should match the job with "100% Remote" in title
+        jobs = db.search_jobs("100%")
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+
+class TestJobStatus:
+    def test_job_status_table_exists(self, db):
+        tables = db.list_tables()
+        assert "job_status" in tables
+
+    def test_upsert_status_favorited(self, db):
+        db.upsert_status("ev1", favorited=True)
+        status = db.get_status("ev1")
+        assert status is not None
+        assert status["favorited"] == 1
+        assert status["applied"] == 0
+
+    def test_get_status_returns_status(self, db):
+        db.upsert_status("ev1", favorited=True, applied=False)
+        status = db.get_status("ev1")
+        assert status["favorited"] == 1
+        assert status["applied"] == 0
+        assert status["event_id"] == "ev1"
+
+    def test_get_status_not_found(self, db):
+        assert db.get_status("nonexistent") is None
+
+    def test_toggle_favorited(self, db):
+        # First call: set favorited=1
+        db.upsert_status("ev1", favorited=True)
+        assert db.get_status("ev1")["favorited"] == 1
+        # Second call: toggle to 0
+        db.upsert_status("ev1", favorited=True)  # already True, toggles off
+        assert db.get_status("ev1")["favorited"] == 0
+
+    def test_toggle_applied(self, db):
+        db.upsert_status("ev1", applied=True)
+        assert db.get_status("ev1")["applied"] == 1
+        db.upsert_status("ev1", applied=True)  # toggle off
+        assert db.get_status("ev1")["applied"] == 0
+
+    def test_list_jobs_filter_favorited(self, db):
+        db.upsert_job("j1", "d1", "pub1", 1, 101, "{}", 1000)
+        db.upsert_job("j2", "d2", "pub2", 1, 101, "{}", 1000)
+        db.upsert_status("j1", favorited=True)
+        jobs = db.list_jobs(favorited=True)
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+    def test_list_jobs_filter_applied(self, db):
+        db.upsert_job("j1", "d1", "pub1", 1, 101, "{}", 1000)
+        db.upsert_job("j2", "d2", "pub2", 2, 201, "{}", 1000)
+        db.upsert_status("j2", applied=True)
+        jobs = db.list_jobs(applied=True)
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j2"
+
+    def test_list_jobs_filter_favorited_and_province(self, db):
+        db.upsert_job("j1", "d1", "pub1", 1, 101, "{}", 1000)
+        db.upsert_job("j2", "d2", "pub2", 2, 201, "{}", 1000)
+        db.upsert_status("j1", favorited=True)
+        db.upsert_status("j2", favorited=True)
+        jobs = db.list_jobs(province_code=1, favorited=True)
+        assert len(jobs) == 1
+        assert jobs[0]["event_id"] == "j1"
+
+
+class TestProfiles:
+    """Tests for user profiles storage."""
+
+    def test_profiles_table_exists(self, db):
+        """Profile table exists in database."""
+        tables = db.list_tables()
+        assert "profiles" in tables
+
+    def test_upsert_profile(self, db):
+        """Can store a user profile."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice","bio":"Developer"}',
+            created_at=1000,
+        )
+        profile = db.get_profile("aa" * 32)
+        assert profile is not None
+        assert profile["pubkey"] == "aa" * 32
+        assert profile["name"] == "Alice"
+
+    def test_upsert_replaces_profile(self, db):
+        """Upsert replaces existing profile with same pubkey."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice"}',
+            created_at=1000,
+        )
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev2",
+            d_tag="profile_1",
+            content='{"name":"Bob"}',
+            created_at=2000,
+        )
+        profile = db.get_profile("aa" * 32)
+        assert profile["name"] == "Bob"
+        assert profile["event_id"] == "ev2"
+
+    def test_get_profile_not_found(self, db):
+        """Returns None for non-existent profile."""
+        profile = db.get_profile("nonexistent")
+        assert profile is None
+
+    def test_get_own_profile(self, db):
+        """Can retrieve own profile by pubkey."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice","bio":"Dev"}',
+            created_at=1000,
+        )
+        own = db.get_own_profile("aa" * 32)
+        assert own is not None
+        assert own["name"] == "Alice"
+
+    def test_delete_profile(self, db):
+        """Can delete a profile."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice"}',
+            created_at=1000,
+        )
+        db.delete_profile("aa" * 32)
+        profile = db.get_profile("aa" * 32)
+        assert profile is None


### PR DESCRIPTION
## Summary
Feature #3: User Profile - Task 1 Complete

**Storage Layer:**
- `profiles` table with pubkey, event_id, d_tag, content, created_at
- `upsert_profile`: store/update user profile
- `get_profile`: retrieve profile by pubkey
- `get_own_profile`: alias for get_profile
- `delete_profile`: remove profile by pubkey

**Test Plan:**
- [x] 135 tests passing (6 new profile tests)
- Clean PR: only profiles storage changes, no duplicate Feature #6 code