### PR TITLE
feat: add user profiles table and CRUD methods

### DIFF
--- a/cli/storage.py
+++ b/cli/storage.py
@@ -1,5 +1,6 @@
 """SQLite local storage for jobs, regions, and config."""
 
+import json
 import sqlite3
 import time
 
@@ -40,6 +41,14 @@ class Storage:
                 updated_at INTEGER DEFAULT (unixepoch('now'))
             );
             CREATE INDEX IF NOT EXISTS idx_job_status_event_id ON job_status(event_id);
+            CREATE TABLE IF NOT EXISTS profiles (
+                pubkey TEXT PRIMARY KEY,
+                event_id TEXT UNIQUE,
+                d_tag TEXT UNIQUE,
+                content TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                received_at INTEGER NOT NULL DEFAULT 0
+            );
         """)
         self._conn.commit()
 
@@ -241,3 +250,47 @@ class Storage:
         query += " ORDER BY jobs.created_at DESC"
         rows = self._conn.execute(query, params).fetchall()
         return [dict(r) for r in rows]
+
+    # ── Profiles ──
+
+    def upsert_profile(
+        self,
+        pubkey: str,
+        event_id: str,
+        d_tag: str,
+        content: str,
+        created_at: int,
+    ):
+        """Store or update a user profile."""
+        self._conn.execute(
+            """INSERT OR REPLACE INTO profiles
+               (pubkey, event_id, d_tag, content, created_at, received_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (pubkey, event_id, d_tag, content, created_at, int(time.time())),
+        )
+        self._conn.commit()
+
+    def get_profile(self, pubkey: str) -> dict | None:
+        """Get profile by pubkey."""
+        row = self._conn.execute(
+            "SELECT * FROM profiles WHERE pubkey = ?", (pubkey,)
+        ).fetchone()
+        if not row:
+            return None
+        profile = dict(row)
+        # Parse JSON content to extract name for convenience
+        try:
+            content = json.loads(profile.get("content", "{}"))
+            profile["name"] = content.get("name", "")
+        except (json.JSONDecodeError, TypeError):
+            profile["name"] = ""
+        return profile
+
+    def get_own_profile(self, pubkey: str) -> dict | None:
+        """Alias for get_profile."""
+        return self.get_profile(pubkey)
+
+    def delete_profile(self, pubkey: str):
+        """Delete profile by pubkey."""
+        self._conn.execute("DELETE FROM profiles WHERE pubkey = ?", (pubkey,))
+        self._conn.commit()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -279,3 +279,77 @@ class TestJobStatus:
         jobs = db.list_jobs(province_code=1, favorited=True)
         assert len(jobs) == 1
         assert jobs[0]["event_id"] == "j1"
+
+
+class TestProfiles:
+    """Tests for user profiles storage."""
+
+    def test_profiles_table_exists(self, db):
+        """Profile table exists in database."""
+        tables = db.list_tables()
+        assert "profiles" in tables
+
+    def test_upsert_profile(self, db):
+        """Can store a user profile."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice","bio":"Developer"}',
+            created_at=1000,
+        )
+        profile = db.get_profile("aa" * 32)
+        assert profile is not None
+        assert profile["pubkey"] == "aa" * 32
+        assert profile["name"] == "Alice"
+
+    def test_upsert_replaces_profile(self, db):
+        """Upsert replaces existing profile with same pubkey."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice"}',
+            created_at=1000,
+        )
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev2",
+            d_tag="profile_1",
+            content='{"name":"Bob"}',
+            created_at=2000,
+        )
+        profile = db.get_profile("aa" * 32)
+        assert profile["name"] == "Bob"
+        assert profile["event_id"] == "ev2"
+
+    def test_get_profile_not_found(self, db):
+        """Returns None for non-existent profile."""
+        profile = db.get_profile("nonexistent")
+        assert profile is None
+
+    def test_get_own_profile(self, db):
+        """Can retrieve own profile by pubkey."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice","bio":"Dev"}',
+            created_at=1000,
+        )
+        own = db.get_own_profile("aa" * 32)
+        assert own is not None
+        assert own["name"] == "Alice"
+
+    def test_delete_profile(self, db):
+        """Can delete a profile."""
+        db.upsert_profile(
+            pubkey="aa" * 32,
+            event_id="ev1",
+            d_tag="profile_1",
+            content='{"name":"Alice"}',
+            created_at=1000,
+        )
+        db.delete_profile("aa" * 32)
+        profile = db.get_profile("aa" * 32)
+        assert profile is None


### PR DESCRIPTION
## Summary
Feature #3: User Profile - Task 1 Storage Layer

**Storage Layer:**
- `profiles` table with pubkey, event_id, d_tag, content, created_at
- `upsert_profile`: store/update user profile
- `get_profile`: retrieve profile by pubkey
- `get_own_profile`: alias for get_profile
- `delete_profile`: remove profile by pubkey

**Test Plan:**
- [x] 135 tests passing (6 new profile tests)
- [x] Clean PR based on current upstream/master