### PR TITLE
fix: return int in RegionMapping name_to_code methods

### DIFF
--- a/cli/models.py
+++ b/cli/models.py
@@ -58,16 +58,16 @@ class RegionMapping:
     cities: dict[str, str]  # code -> name
     province_city: dict[str, list[int]]  # province_code -> [city_codes]
 
-    def province_name_to_code(self, name: str) -> str | None:
+    def province_name_to_code(self, name: str) -> int | None:
         for code, n in self.provinces.items():
             if n == name:
-                return code
+                return int(code)
         return None
 
-    def city_name_to_code(self, name: str) -> str | None:
+    def city_name_to_code(self, name: str) -> int | None:
         for code, n in self.cities.items():
             if n == name:
-                return code
+                return int(code)
         return None
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -70,7 +70,7 @@ class TestRegionMapping:
             "province_city": {},
         })
         mapping = parse_region_mapping(raw)
-        assert mapping.province_name_to_code("北京") == "1"
+        assert mapping.province_name_to_code("北京") == 1
         assert mapping.province_name_to_code("不存在") is None
 
     def test_name_to_code_city(self):
@@ -81,5 +81,5 @@ class TestRegionMapping:
             "province_city": {},
         })
         mapping = parse_region_mapping(raw)
-        assert mapping.city_name_to_code("北京市") == "101"
+        assert mapping.city_name_to_code("北京市") == 101
         assert mapping.city_name_to_code("不存在") is None


### PR DESCRIPTION
## Summary

修复 `RegionMapping.province_name_to_code` / `city_name_to_code` 返回类型与注解不一致的 bug：
- 返回值从 `str` 改为 `int`（`return int(code)`）
- 返回类型注解从 `str | None` 改为 `int | None`

## Changes

- `cli/models.py`：两处 `return code` → `return int(code)`，注解同步修正
- `tests/test_models.py`：断言预期值从 `"1"` → `1`、`"101"` → `101`

修复 GitHub Issue #15。

🤖 Generated with [Claude Code](https://claude.com/claude-code)