### PR TITLE
feat: GitHub Pages deployment — build output to docs/

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,13 +1,13 @@
 import { defineConfig } from 'vite';
 import preact from '@preact/preset-vite';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [preact()],
   // Deploy to /AgentBoss/ subdirectory on GitHub Pages
   base: '/AgentBoss/',
   build: {
-    outDir: 'dist',
-    emptyOutDir: true,
+    outDir: resolve(__dirname, '../docs'),
   },
   server: {
     port: 3000,


### PR DESCRIPTION
## Summary

Redirect Vite build output to `docs/` for GitHub Pages deployment from `master/docs`.

## Changes

- `web/vite.config.js`: `outDir` changed from `dist/` to `../docs` (repo root `docs/`); `emptyOutDir` removed to preserve existing static files

## Verification

- [x] `npm run build` succeeds
- [x] `docs/index.html` generated (Vite frontend entry)
- [x] `docs/assets/` contains JS/CSS bundles
- [x] Existing `docs/superpowers/` specs preserved

## After Merge

GitHub Pages automatically serves the static site from `master/docs`.

## Note

docsify docs are accessible via direct file URLs (`/docs/superpowers/specs/`) or can be rebuilt into `docs/` after the frontend build.

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)