### PR TITLE
feat(web): Vercel deployment — env-driven config + docsify bundling

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "npm install && npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "framework": "vite"
+}

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,16 +1,39 @@
 import { defineConfig } from 'vite';
 import preact from '@preact/preset-vite';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
+import { copyFileSync, mkdirSync, readdirSync, statSync } from 'fs';
+
+const isVercel = process.env.VITE_BASE_PATH === '/';
+
+function copyDir(src, dest) {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src)) {
+    const srcPath = join(src, entry);
+    const destPath = join(dest, entry);
+    statSync(srcPath).isDirectory()
+      ? copyDir(srcPath, destPath)
+      : copyFileSync(srcPath, destPath);
+  }
+}
+
+function docsifyCopyPlugin() {
+  return {
+    name: 'docsify-copy',
+    closeBundle() {
+      const src = resolve(__dirname, '../docs/superpowers');
+      const dest = resolve(__dirname, 'dist/superpowers');
+      copyDir(src, dest);
+      console.log('[docsify-copy] copied to dist/superpowers/');
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [preact()],
-  // Deploy to /AgentBoss/ subdirectory on GitHub Pages
-  base: '/AgentBoss/',
+  plugins: [preact(), docsifyCopyPlugin()],
+  base: process.env.VITE_BASE_PATH || '/',
   build: {
-    outDir: resolve(__dirname, '../docs'),
+    outDir: isVercel ? 'dist' : resolve(__dirname, '../docs'),
+    emptyOutDir: true,
   },
-  server: {
-    port: 3000,
-    open: true,
-  },
+  server: { port: 3000, open: true },
 });


### PR DESCRIPTION
## Summary

Enable full Vercel deployment: Preact frontend + docsify docs, all served from `dist/`.

## Changes

- `web/vite.config.js`:
  - `docsifyCopyPlugin()` copies `docs/superpowers/` → `dist/superpowers/` after build
  - `base` and `outDir` driven by `VITE_BASE_PATH` env var
  - `emptyOutDir: true`
- `web/vercel.json`: Vercel build + output config

## URLs After Deploy

- Frontend: `https://*.vercel.app/`
- Docs: `https://*.vercel.app/superpowers/`

## Vercel Setup

1. Import `nicholasyangyang/AgentBoss` on vercel.com
2. Root Directory: `web/`
3. Environment Variable: `VITE_BASE_PATH` = `/`
4. Deploy

## Verification

- [x] `VITE_BASE_PATH=/ npm run build` succeeds
- [x] `dist/index.html` exists (frontend)
- [x] `dist/superpowers/index.html` exists (docsify)

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)