### PR TITLE
feat(web): search debounce + npub cache + toast delay (#33)

### DIFF
--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -37,7 +37,10 @@ export function App() {
     toast.className = 'toast success';
     toast.textContent = t('success');
     document.body.appendChild(toast);
-    setTimeout(() => toast.remove(), 3000);
+    setTimeout(() => {
+      setShowPublish(false);
+      toast.remove();
+    }, 2500);
   };
 
   return (

--- a/web/src/components/Navbar.jsx
+++ b/web/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'preact/hooks';
+import { useState, useRef } from 'preact/hooks';
 import { useAuth } from '../hooks/useAuth.js';
 import { LanguageSwitch } from './LanguageSwitch.jsx';
 import { hexToNpub } from '../lib/nostr.js';
@@ -7,11 +7,17 @@ import { t } from '../lib/i18n.js';
 export function Navbar({ onSearch, onPublish }) {
   const [searchValue, setSearchValue] = useState('');
   const { pubkey, hasSigner } = useAuth();
+  const debounceRef = useRef(null);
 
   const handleSearch = (e) => {
     setSearchValue(e.target.value);
-    if (onSearch) onSearch(e.target.value);
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      if (onSearch) onSearch(e.target.value);
+    }, 500);
   };
+
+  const npub = pubkey ? hexToNpub(pubkey) : null;
 
   return (
     <nav class="navbar">
@@ -37,8 +43,8 @@ export function Navbar({ onSearch, onPublish }) {
           <LanguageSwitch />
 
           {pubkey ? (
-            <span class="pubkey-badge" title={hexToNpub(pubkey)}>
-              ⚡ {hexToNpub(pubkey).slice(0, 12)}…
+            <span class="pubkey-badge" title={npub}>
+              ⚡ {npub.slice(0, 12)}…
             </span>
           ) : hasSigner ? (
             <span class="pubkey-badge" style="color: var(--accent)">


### PR DESCRIPTION
## Summary
Issue #33 UX improvements — 3 small changes.

## Changes
- `Navbar.jsx`: Search input debounced 500ms via `useRef` + `setTimeout` — prevents relay reconnect on every keystroke
- `Navbar.jsx`: `hexToNpub` called once, result cached in `npub` variable — no duplicate calls in title + display
- `app.jsx`: Toast displays for 2.5s before modal closes — user sees confirmation before form disappears

## Verification
- [x] `npx vitest run` — 28/28 tests pass

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)