### PR TITLE
feat(web): JobCard contact + JobList retry + empty CTA (#35)

### DIFF
--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -12,7 +12,7 @@ export function App() {
   const [showPublish, setShowPublish] = useState(false);
   // Force re-render when language changes via subscribeToLang
   const [_langVersion, setLangVersion] = useState(0);
-  const { jobs, loading, error } = useJobs({ searchQuery });
+  const { jobs, loading, error, reload } = useJobs({ searchQuery });
   const { count: favCount } = useFavorites();
 
   // Subscribe to language changes — triggers re-render on switch
@@ -80,7 +80,7 @@ export function App() {
                   {loading ? t('loading_jobs') : `${jobs.length} ${t('jobs_count')}`}
                 </span>
               </div>
-              <JobList jobs={jobs} loading={loading} error={error} />
+              <JobList jobs={jobs} loading={loading} error={error} onJobClick={() => {}} onRetry={reload} onPublish={handlePublishClick} />
             </div>
 
             {/* Sidebar */}

--- a/web/src/components/JobCard.jsx
+++ b/web/src/components/JobCard.jsx
@@ -62,6 +62,17 @@ export function JobCard({ job, onClick }) {
           ⚡ {shortPubkey(job.pubkey)}
         </span>
       </div>
+
+      {job.contact && (
+        <div class="job-contact">
+          📧{' '}
+          {job.contact.includes('@') ? (
+            <a href={`mailto:${job.contact}`}>{job.contact}</a>
+          ) : (
+            <span class="job-contact-text">{job.contact}</span>
+          )}
+        </div>
+      )}
     </article>
   );
 }

--- a/web/src/components/JobList.jsx
+++ b/web/src/components/JobList.jsx
@@ -1,7 +1,7 @@
 import { JobCard } from './JobCard.jsx';
 import { t } from '../lib/i18n.js';
 
-export function JobList({ jobs, loading, error, onJobClick }) {
+export function JobList({ jobs, loading, error, onJobClick, onRetry, onPublish }) {
   if (loading) {
     return (
       <div class="jobs-grid">
@@ -18,6 +18,11 @@ export function JobList({ jobs, loading, error, onJobClick }) {
         <div class="empty-state-icon">⚠</div>
         <h3>{t('load_error')}</h3>
         <p>{error}</p>
+        {onRetry && (
+          <button class="btn btn-secondary" onClick={onRetry}>
+            {t('retry')}
+          </button>
+        )}
       </div>
     );
   }
@@ -28,6 +33,11 @@ export function JobList({ jobs, loading, error, onJobClick }) {
         <div class="empty-state-icon">📭</div>
         <h3>{t('empty_jobs')}</h3>
         <p>{t('empty_sub')}</p>
+        {onPublish && (
+          <button class="btn btn-primary" onClick={onPublish}>
+            {t('publish_btn')}
+          </button>
+        )}
       </div>
     );
   }

--- a/web/src/lib/i18n.js
+++ b/web/src/lib/i18n.js
@@ -53,6 +53,8 @@ export const translations = {
     err_post: '发布失败，请重试',
     success: '✓ 职位已发布到 Nostr！',
     err_alert_nip07: '请先安装 NIP-07 扩展（如 Alby 或 nos2x）来发布职位',
+    retry: '重试',
+    contact: '联系方式',
   },
   en: {
     search_placeholder: 'Search jobs, companies...',
@@ -106,6 +108,8 @@ export const translations = {
     err_post: 'Failed to post, please try again',
     success: '✓ Job posted to Nostr!',
     err_alert_nip07: 'Please install a NIP-07 extension (e.g. Alby or nos2x) to post',
+    retry: 'Retry',
+    contact: 'Contact',
   },
 };
 

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -509,6 +509,23 @@ a:hover { color: var(--text-accent); }
   gap: 4px;
 }
 
+/* Job Contact */
+.job-contact {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+.job-contact a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.job-contact a:hover {
+  text-decoration: underline;
+}
+
 /* ── Sidebar ────────────────────────────────── */
 .sidebar {
   position: sticky;
@@ -791,6 +808,10 @@ a:hover { color: var(--text-accent); }
   font-size: 13px;
   max-width: 300px;
   margin: 0 auto;
+}
+
+.empty-state .btn {
+  margin-top: 16px;
 }
 
 /* ── Footer ─────────────────────────────────── */


### PR DESCRIPTION
## Summary
Issue #35 UX improvements for JobCard and JobList.

## Changes
- `i18n.js`: `retry` + `contact` translation keys (zh/en)
- `JobCard.jsx`: Contact field with 📧 icon, email detected and rendered as mailto: link
- `JobList.jsx`: Error state retry button (calls `reload`), empty state CTA button (opens publish modal)
- `app.jsx`: Pass `onRetry={reload}` + `onPublish={handlePublishClick}` to JobList
- `index.css`: `.job-contact` styles, `.empty-state .btn` margin

## Verification
- [x] `npx vitest run` — 28/28 tests pass

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)