### PR TITLE
fix(web): useJobs memory leak + race guard + favicon (#37)

### DIFF
--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="6" fill="#0d0d0d"/>
-  <text x="6" y="23" font-family="Georgia, serif" font-size="20" font-weight="900" fill="#f59e0b">A</text>
-  <rect x="6" y="25" width="20" height="2" rx="1" fill="#f59e0b" opacity="0.6"/>
+  <rect width="32" height="32" rx="8" fill="#1a1a2e"/>
+  <path d="M18 4L8 18h8l-2 10 12-14h-9l3-10z" fill="#f59e0b"/>
 </svg>

--- a/web/src/hooks/useJobs.js
+++ b/web/src/hooks/useJobs.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'preact/hooks';
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
 import { createRelayClient, parseJobEvent, buildJobFilter } from '../lib/relay.js';
 
 const FAVORITES_KEY = 'agentboss_favorites';
@@ -7,8 +7,10 @@ export function useJobs({ province, city, searchQuery } = {}) {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const requestIdRef = useRef(0);
 
   const loadJobs = useCallback(async () => {
+    const currentId = ++requestIdRef.current;
     setLoading(true);
     setError(null);
 
@@ -24,10 +26,10 @@ export function useJobs({ province, city, searchQuery } = {}) {
       });
 
       relay.onEOSE(() => {
-        // Sort by created_at desc
+        if (currentId !== requestIdRef.current) { relay.close(); return; }
+
         allJobs.sort((a, b) => b.created_at - a.created_at);
 
-        // Filter by search query
         let filtered = allJobs;
         if (searchQuery) {
           const q = searchQuery.toLowerCase();
@@ -46,6 +48,7 @@ export function useJobs({ province, city, searchQuery } = {}) {
 
       relay.subscribe('jobs', buildJobFilter({ province, city }));
     } catch (err) {
+      if (currentId !== requestIdRef.current) { relay.close(); return; }
       setError(err.message);
       setLoading(false);
       relay.close();
@@ -54,6 +57,9 @@ export function useJobs({ province, city, searchQuery } = {}) {
 
   useEffect(() => {
     loadJobs();
+    return () => {
+      requestIdRef.current++;
+    };
   }, [loadJobs]);
 
   return { jobs, loading, error, reload: loadJobs };


### PR DESCRIPTION
## Summary
Issue #37 reliability fixes.

## Changes
- `useJobs.js`:
  - `useEffect` cleanup increments `requestIdRef.current++` to invalidate any in-flight callbacks
  - `loadJobs`: `requestIdRef` guards `onEOSE` and `catch` — ignores results from superseded requests
  - Prevents state update on unmounted component (React "Can't perform a React state update on an unmounted component")
- `public/favicon.svg`: ⚡ amber bolt on dark rounded square
- `index.html`: already had `<link rel="icon">` pointing to `/favicon.svg`

## Verification
- [x] `npx vitest run` — 28/28 tests pass

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)