### PR TITLE
feat(web): My Jobs view + edit/delete own jobs (#42)

### DIFF
--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -14,12 +14,16 @@ export function App() {
   const [searchQuery, setSearchQuery] = useState('');
   const [showPublish, setShowPublish] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState(null);
+  const [view, setView] = useState('all');
+  const [editingJob, setEditingJob] = useState(null);
   // Force re-render when language changes via subscribeToLang
   const [_langVersion, setLangVersion] = useState(0);
   const { jobs, loading, error, reload } = useJobs({ searchQuery });
   const { count: favCount } = useFavorites();
   const { pubkey } = useAuth();
   const { markDeleted } = useDeletedJobs();
+
+  const myJobs = pubkey ? jobs.filter((j) => j.pubkey === pubkey) : [];
 
   // Subscribe to language changes — triggers re-render on switch
   useEffect(() => {
@@ -76,6 +80,26 @@ export function App() {
         onPublish={handlePublishClick}
       />
 
+      {/* View Tabs */}
+      {hasSigner() && (
+        <div style="display: flex; justify-content: center; padding: 12px 0 0;">
+          <div class="navbar-tabs">
+            <button
+              class={`navbar-tab ${view === 'all' ? 'active' : ''}`}
+              onClick={() => setView('all')}
+            >
+              {t('latest_jobs')}
+            </button>
+            <button
+              class={`navbar-tab ${view === 'mine' ? 'active' : ''}`}
+              onClick={() => setView('mine')}
+            >
+              {t('my_jobs_tab')}
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Main Content */}
       <main class="main-content">
         <div class="container">
@@ -90,13 +114,54 @@ export function App() {
           <div class="jobs-layout">
             {/* Job Feed */}
             <div>
-              <div class="jobs-section-title">
-                <span>{t('latest_jobs')}</span>
-                <span style="color: var(--text-muted); font-size: 11px">
-                  {loading ? t('loading_jobs') : `${jobs.length} ${t('jobs_count')}`}
-                </span>
-              </div>
-              <JobList jobs={jobs} loading={loading} error={error} onJobClick={() => {}} onRetry={reload} onPublish={handlePublishClick} onDelete={pubkey ? (j) => setDeleteTarget(j) : undefined} />
+              {view === 'mine' ? (
+                <>
+                  <div class="jobs-section-title">
+                    <span>{t('my_jobs_tab')}</span>
+                    <span style="color: var(--text-muted); font-size: 11px">
+                      {loading ? t('loading_jobs') : `${myJobs.length} ${t('jobs_count')}`}
+                    </span>
+                  </div>
+                  <JobList
+                    jobs={myJobs}
+                    loading={loading}
+                    error={error}
+                    onJobClick={() => {}}
+                    onRetry={reload}
+                    onPublish={handlePublishClick}
+                    onDelete={(j) => setDeleteTarget(j)}
+                    onEdit={(j) => setEditingJob(j)}
+                  />
+                  {!loading && myJobs.length === 0 && (
+                    <div class="empty-state">
+                      <div class="empty-state-icon">📝</div>
+                      <h3>{t('no_my_jobs')}</h3>
+                      <button class="btn btn-primary" onClick={handlePublishClick}>
+                        {t('publish_btn')}
+                      </button>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div class="jobs-section-title">
+                    <span>{t('latest_jobs')}</span>
+                    <span style="color: var(--text-muted); font-size: 11px">
+                      {loading ? t('loading_jobs') : `${jobs.length} ${t('jobs_count')}`}
+                    </span>
+                  </div>
+                  <JobList
+                    jobs={jobs}
+                    loading={loading}
+                    error={error}
+                    onJobClick={() => {}}
+                    onRetry={reload}
+                    onPublish={handlePublishClick}
+                    onDelete={pubkey ? (j) => setDeleteTarget(j) : undefined}
+                    onEdit={pubkey ? (j) => setEditingJob(j) : undefined}
+                  />
+                </>
+              )}
             </div>
 
             {/* Sidebar */}
@@ -113,6 +178,12 @@ export function App() {
                     <div class="stat-value">{favCount}</div>
                     <div class="stat-label">{t('favorites')}</div>
                   </div>
+                  {pubkey && (
+                    <div class="stat-item">
+                      <div class="stat-value">{myJobs.length}</div>
+                      <div class="stat-label">{t('my_jobs')}</div>
+                    </div>
+                  )}
                 </div>
               </div>
 
@@ -180,6 +251,15 @@ export function App() {
         <PublishForm
           onClose={() => setShowPublish(false)}
           onSuccess={handlePublishSuccess}
+        />
+      )}
+
+      {/* Edit Modal — mutually exclusive with DeleteModal */}
+      {editingJob && !deleteTarget && (
+        <PublishForm
+          jobToEdit={editingJob}
+          onClose={() => setEditingJob(null)}
+          onSuccess={() => { setEditingJob(null); reload(); }}
         />
       )}
 

--- a/web/src/components/JobCard.jsx
+++ b/web/src/components/JobCard.jsx
@@ -15,7 +15,7 @@ function shortPubkey(hex, len = 6) {
   return `${hex.slice(0, len)}…`;
 }
 
-export function JobCard({ job, onClick, onDelete }) {
+export function JobCard({ job, onClick, onDelete, onEdit }) {
   const { isFavorite, toggleFavorite } = useFavorites();
   const fav = isFavorite(job.id);
 
@@ -37,6 +37,16 @@ export function JobCard({ job, onClick, onDelete }) {
           >
             {fav ? '★' : '☆'}
           </button>
+          {onEdit && (
+            <button
+              class="job-edit"
+              onClick={(e) => { e.stopPropagation(); onEdit(job); }}
+              title={t('edit')}
+              aria-label={t('edit')}
+            >
+              {t('edit')}
+            </button>
+          )}
           {onDelete && (
             <button
               class="job-delete"

--- a/web/src/components/JobList.jsx
+++ b/web/src/components/JobList.jsx
@@ -1,7 +1,7 @@
 import { JobCard } from './JobCard.jsx';
 import { t } from '../lib/i18n.js';
 
-export function JobList({ jobs, loading, error, onJobClick, onRetry, onPublish, onDelete }) {
+export function JobList({ jobs, loading, error, onJobClick, onRetry, onPublish, onDelete, onEdit }) {
   if (loading) {
     return (
       <div class="jobs-grid">
@@ -45,7 +45,7 @@ export function JobList({ jobs, loading, error, onJobClick, onRetry, onPublish, 
   return (
     <div class="jobs-grid">
       {jobs.map((job) => (
-        <JobCard key={job.id} job={job} onClick={onJobClick} onDelete={onDelete} />
+        <JobCard key={job.id} job={job} onClick={onJobClick} onDelete={onDelete} onEdit={onEdit} />
       ))}
     </div>
   );

--- a/web/src/components/PublishForm.jsx
+++ b/web/src/components/PublishForm.jsx
@@ -1,17 +1,20 @@
 import { useState } from 'preact/hooks';
-import { signEvent } from '../lib/nostr.js';
+import { signEvent, deleteJob } from '../lib/nostr.js';
 import { createRelayClient, generateDTag } from '../lib/relay.js';
+import { useDeletedJobs } from '../hooks/useDeletedJobs.js';
 import { t } from '../lib/i18n.js';
 
-export function PublishForm({ onClose, onSuccess }) {
+export function PublishForm({ jobToEdit, onClose, onSuccess }) {
+  const isEditing = !!jobToEdit;
+  const { markDeleted } = useDeletedJobs();
   const [form, setForm] = useState({
-    title: '',
-    company: '',
-    salary: '',
-    province: '',
-    city: '',
-    description: '',
-    contact: '',
+    title: jobToEdit?.title || '',
+    company: jobToEdit?.company || '',
+    salary: jobToEdit?.salary || '',
+    province: jobToEdit?.province || '',
+    city: jobToEdit?.city || '',
+    description: jobToEdit?.description || '',
+    contact: jobToEdit?.contact || '',
   });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
@@ -32,6 +35,11 @@ export function PublishForm({ onClose, onSuccess }) {
     setSubmitting(true);
 
     try {
+      if (isEditing) {
+        await deleteJob(jobToEdit.d_tag, jobToEdit.pubkey);
+        markDeleted(jobToEdit.d_tag);
+      }
+
       const dTag = generateDTag();
       const event = {
         kind: 30078,
@@ -75,7 +83,7 @@ export function PublishForm({ onClose, onSuccess }) {
     <div class="modal-overlay" onClick={(e) => e.target === e.currentTarget && onClose && onClose()}>
       <div class="modal" role="dialog" aria-modal="true" aria-labelledby="publish-title">
         <div class="modal-header">
-          <h2 class="modal-title" id="publish-title">{t('form_title')}</h2>
+          <h2 class="modal-title" id="publish-title">{isEditing ? t('edit_job') : t('form_title')}</h2>
           <button class="modal-close" onClick={onClose} aria-label="Close">×</button>
         </div>
 

--- a/web/src/lib/i18n.js
+++ b/web/src/lib/i18n.js
@@ -60,6 +60,11 @@ export const translations = {
     delete_confirm: '删除后无法恢复。',
     cancel: '取消',
     delete_confirm_btn: '确认删除',
+    my_jobs_tab: '我的职位',
+    my_jobs: '我的职位',
+    no_my_jobs: '你还没有发布过职位',
+    edit: '编辑',
+    edit_job: '编辑职位',
   },
   en: {
     search_placeholder: 'Search jobs, companies...',
@@ -120,6 +125,11 @@ export const translations = {
     delete_confirm: 'This action cannot be undone.',
     cancel: 'Cancel',
     delete_confirm_btn: 'Confirm Delete',
+    my_jobs_tab: 'My Jobs',
+    my_jobs: 'My Jobs',
+    no_my_jobs: "You haven't posted any jobs yet",
+    edit: 'Edit',
+    edit_job: 'Edit Job',
   },
 };
 

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -1003,3 +1003,47 @@ a:hover { color: var(--text-accent); }
   border-color: var(--text-muted);
   color: var(--text);
 }
+
+/* ── Navbar Tabs ──────────────────────────── */
+.navbar-tabs {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.navbar-tab {
+  background: none;
+  border: none;
+  padding: 4px 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+  font-family: inherit;
+}
+.navbar-tab:hover {
+  background: var(--bg-secondary);
+  color: var(--text);
+}
+.navbar-tab.active {
+  background: var(--bg-secondary);
+  color: var(--accent);
+  font-weight: 500;
+}
+
+/* ── Edit Button ──────────────────────────── */
+.job-edit {
+  background: none;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: #93c5fd;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-family: inherit;
+}
+.job-edit:hover {
+  background: rgba(59, 130, 246, 0.12);
+}


### PR DESCRIPTION
## Summary

My Jobs view + edit functionality for Issue #42.

## Changes

- `i18n.js`: `my_jobs_tab`, `my_jobs`, `no_my_jobs`, `edit`, `edit_job` keys
- `PublishForm.jsx`: `jobToEdit` prop — pre-fills form, renames title to "Edit Job", deletes old job via NIP-78 before publishing new one
- `JobCard.jsx`: `onEdit` prop — edit button shown on owned jobs (same condition as delete button)
- `JobList.jsx`: `onEdit` prop — passes to JobCard
- `app.jsx`:
  - `view` state: 'all' | 'mine'
  - `editingJob` state for edit flow
  - myJobs filtered by pubkey
  - Navbar tabs (shown when signer connected)
  - Sidebar stats: my jobs count
  - Edit modal + Delete modal rendered mutually exclusively
- `index.css`: `.navbar-tab`, `.job-edit` styles

## Verification

- [ ] My Jobs tab visible only when NIP-07 signer connected
- [ ] My Jobs shows only current user's posts
- [ ] Empty state with CTA when no jobs posted
- [ ] Edit button opens pre-filled PublishForm
- [ ] Edit submits: old job deleted + new job published
- [ ] Sidebar shows my jobs count
- [ ] `npm test` passes (32/32 ✓)

Closes #42.