### PR TITLE
feat(web): unified toast system — useToast + ToastContainer (#44)

### DIFF
--- a/web/src/app.jsx
+++ b/web/src/app.jsx
@@ -3,9 +3,11 @@ import { Navbar } from './components/Navbar.jsx';
 import { JobList } from './components/JobList.jsx';
 import { PublishForm } from './components/PublishForm.jsx';
 import { DeleteModal } from './components/DeleteModal.jsx';
+import { ToastContainer } from './components/ToastContainer.jsx';
 import { useJobs } from './hooks/useJobs.js';
 import { useFavorites } from './hooks/useFavorites.js';
 import { useDeletedJobs } from './hooks/useDeletedJobs.js';
+import { useToast } from './hooks/useToast.js';
 import { hasSigner, deleteJob } from './lib/nostr.js';
 import { useAuth } from './hooks/useAuth.js';
 import { t, getLang, subscribeToLang } from './lib/i18n.js';
@@ -22,6 +24,7 @@ export function App() {
   const { count: favCount } = useFavorites();
   const { pubkey } = useAuth();
   const { markDeleted } = useDeletedJobs();
+  const { toasts, showToast, dismissToast } = useToast();
 
   const myJobs = pubkey ? jobs.filter((j) => j.pubkey === pubkey) : [];
 
@@ -36,31 +39,32 @@ export function App() {
 
   const handlePublishClick = () => {
     if (!hasSigner()) {
-      alert(t('err_alert_nip07'));
+      showToast(t('toast_nip07_err'), 'error');
       return;
     }
     setShowPublish(true);
   };
 
   const handlePublishSuccess = () => {
-    const toast = document.createElement('div');
-    toast.className = 'toast success';
-    toast.textContent = t('success');
-    document.body.appendChild(toast);
-    setTimeout(() => {
-      setShowPublish(false);
-      toast.remove();
-    }, 2500);
+    showToast(t('toast_published'), 'success');
+    setTimeout(() => setShowPublish(false), 2500);
   };
 
   const handleDeleteConfirm = async (job) => {
     try {
       await deleteJob(job.d_tag, pubkey);
+      showToast(t('toast_deleted'), 'success');
     } catch {
-      // deletion failed silently
+      showToast(t('toast_delete_err'), 'error');
     }
     markDeleted(job.d_tag);
     setDeleteTarget(null);
+  };
+
+  const handleEditSuccess = () => {
+    showToast(t('toast_edited'), 'success');
+    setEditingJob(null);
+    reload();
   };
 
   return (
@@ -259,7 +263,7 @@ export function App() {
         <PublishForm
           jobToEdit={editingJob}
           onClose={() => setEditingJob(null)}
-          onSuccess={() => { setEditingJob(null); reload(); }}
+          onSuccess={handleEditSuccess}
         />
       )}
 
@@ -271,6 +275,9 @@ export function App() {
           onClose={() => setDeleteTarget(null)}
         />
       )}
+
+      {/* Toast Container */}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );
 }

--- a/web/src/components/ToastContainer.jsx
+++ b/web/src/components/ToastContainer.jsx
@@ -1,0 +1,20 @@
+export function ToastContainer({ toasts, onDismiss }) {
+  if (!toasts.length) return null;
+
+  return (
+    <div class="toast-container" role="region" aria-label="Notifications">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          class={`toast ${toast.type === 'error' ? 'toast-error' : 'toast-success'}`}
+          onClick={() => toast.type === 'error' && onDismiss(toast.id)}
+        >
+          <span>{toast.message}</span>
+          {toast.type === 'error' && (
+            <button class="toast-close-btn" onClick={() => onDismiss(toast.id)}>×</button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/hooks/useToast.js
+++ b/web/src/hooks/useToast.js
@@ -1,0 +1,22 @@
+import { useState } from 'preact/hooks';
+
+export function useToast() {
+  const [toasts, setToasts] = useState([]);
+
+  const showToast = (message, type = 'success') => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message, type }]);
+
+    if (type !== 'error') {
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, 3000);
+    }
+  };
+
+  const dismissToast = (id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  return { toasts, showToast, dismissToast };
+}

--- a/web/src/lib/i18n.js
+++ b/web/src/lib/i18n.js
@@ -65,6 +65,11 @@ export const translations = {
     no_my_jobs: '你还没有发布过职位',
     edit: '编辑',
     edit_job: '编辑职位',
+    toast_published: '✓ 职位已发布到 Nostr！',
+    toast_deleted: '✓ 职位已删除',
+    toast_edited: '✓ 职位已更新',
+    toast_delete_err: '✗ 删除失败，请重试',
+    toast_nip07_err: '请先安装 NIP-07 扩展来使用此功能',
   },
   en: {
     search_placeholder: 'Search jobs, companies...',
@@ -130,6 +135,11 @@ export const translations = {
     no_my_jobs: "You haven't posted any jobs yet",
     edit: 'Edit',
     edit_job: 'Edit Job',
+    toast_published: '✓ Job posted to Nostr!',
+    toast_deleted: '✓ Job deleted',
+    toast_edited: '✓ Job updated',
+    toast_delete_err: '✗ Failed to delete, please try again',
+    toast_nip07_err: 'Please install a NIP-07 extension to use this feature',
   },
 };
 

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -1047,3 +1047,57 @@ a:hover { color: var(--text-accent); }
 .job-edit:hover {
   background: rgba(59, 130, 246, 0.12);
 }
+
+/* ── Toast ─────────────────────────────── */
+.toast-container {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  pointer-events: all;
+  max-width: 320px;
+  background: var(--bg-secondary);
+  animation: toast-in 0.2s ease;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.toast-success {
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  color: #86efac;
+}
+
+.toast-error {
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fca5a5;
+  cursor: pointer;
+}
+
+.toast-close-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0;
+  margin-left: auto;
+  opacity: 0.7;
+}
+.toast-close-btn:hover { opacity: 1; }
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(20px); }
+  to { opacity: 1; transform: translateX(0); }
+}


### PR DESCRIPTION
## Summary

Replace alert() + manual DOM toast with unified useToast hook + ToastContainer.

## Changes

- `useToast.js`: showToast(message, type) — success auto-dismiss 3s, error manual close
- `ToastContainer.jsx`: fixed top-right, stacked, animated
- `app.jsx`:
  - handlePublishClick: alert() → showToast(error)
  - handlePublishSuccess: remove document.createElement → showToast(success)
  - handleDeleteConfirm: add showToast(success/error)
  - handleEditSuccess: showToast(t('toast_edited'), 'success')
  - ToastContainer rendered at page level
- `i18n.js`: 5 toast keys (published, deleted, edited, errors)
- `index.css`: .toast-container, .toast-success, .toast-error, toast-in animation

## Verification

- [x] No alert() calls remain
- [x] Publish → success toast
- [x] Delete → success toast
- [x] Edit → success toast
- [x] NIP-07 error → error toast (manual close)
- [x] Delete error → error toast (manual close)
- [x] Multiple toasts stack correctly
- [x] npm test passes (32/32 ✓)

Closes #44.