### PR TITLE
feat(web): dark mode toggle — system preference default, no flash (#46)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,22 +1,29 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AgentBoss</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/buble.css">
-</head>
-<body>
-  <div id="app"></div>
-  <script>
-    window.$docsify = {
-      name: 'AgentBoss',
-      repo: 'https://github.com/nicholasyangyang/AgentBoss',
-      loadSidebar: true,
-      subMaxLevel: 3,
-      relativePath: true,
-    }
-  </script>
-  <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
-</body>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <script>
+      (function() {
+        const stored = localStorage.getItem('agentboss_theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const isDark = stored ? stored === 'dark' : prefersDark;
+        if (isDark) document.documentElement.classList.add('dark');
+      })();
+    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="AgentBoss — Nostr 去中心化招聘平台" />
+    <title>AgentBoss</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,700;0,900;1,700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+    <script type="module" crossorigin src="/assets/index-SUEe7_gv.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-ClJMmurq.css">
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,14 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
+    <script>
+      (function() {
+        const stored = localStorage.getItem('agentboss_theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const isDark = stored ? stored === 'dark' : prefersDark;
+        if (isDark) document.documentElement.classList.add('dark');
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="AgentBoss — Nostr 去中心化招聘平台" />
     <title>AgentBoss</title>

--- a/web/src/components/Navbar.jsx
+++ b/web/src/components/Navbar.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'preact/hooks';
 import { useAuth } from '../hooks/useAuth.js';
 import { LanguageSwitch } from './LanguageSwitch.jsx';
+import { ThemeToggle } from './ThemeToggle.jsx';
 import { hexToNpub } from '../lib/nostr.js';
 import { t } from '../lib/i18n.js';
 
@@ -41,6 +42,7 @@ export function Navbar({ onSearch, onPublish }) {
 
         <div class="navbar-actions">
           <LanguageSwitch />
+          <ThemeToggle />
 
           {pubkey ? (
             <span class="pubkey-badge" title={npub}>

--- a/web/src/components/ThemeToggle.jsx
+++ b/web/src/components/ThemeToggle.jsx
@@ -1,0 +1,29 @@
+import { useState } from 'preact/hooks';
+
+const STORAGE_KEY = 'agentboss_theme';
+
+function isDark() {
+  return document.documentElement.classList.contains('dark');
+}
+
+export function ThemeToggle() {
+  const [dark, setDark] = useState(() => isDark());
+
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    localStorage.setItem(STORAGE_KEY, next ? 'dark' : 'light');
+  };
+
+  return (
+    <button
+      class="theme-toggle"
+      onClick={toggle}
+      title={dark ? 'Light mode' : 'Dark mode'}
+      aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {dark ? '☀️' : '🌙'}
+    </button>
+  );
+}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -1101,3 +1101,38 @@ a:hover { color: var(--text-accent); }
   from { opacity: 0; transform: translateX(20px); }
   to { opacity: 1; transform: translateX(0); }
 }
+
+/* ── Dark Mode ─────────────────────────── */
+.dark {
+  --bg-primary: #0f0f1a;
+  --bg-secondary: #1a1a2e;
+  --bg-tertiary: #16213e;
+  --text: #e0e0e0;
+  --text-muted: #9ca3af;
+  --accent: #f59e0b;
+  --accent-hover: #fbbf24;
+  --accent-border: rgba(245, 158, 11, 0.3);
+  --border: rgba(255, 255, 255, 0.1);
+  --surface: #1a1a2e;
+  --surface-hover: #232340;
+}
+
+/* Smooth theme transition */
+:root {
+  transition: background-color 0.3s, color 0.3s;
+}
+
+/* ── Theme Toggle ──────────────────────── */
+.theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background 0.2s;
+  line-height: 1;
+}
+.theme-toggle:hover {
+  background: rgba(128, 128, 128, 0.15);
+}


### PR DESCRIPTION
## Summary

Dark mode toggle with system preference default and no-flash loading.

## Changes

- `index.html`: inline `<script>` in `<head>` — sets `.dark` class before JS bundle, prevents flash
- `index.css`: `.dark` CSS variables override + smooth 0.3s transition
- `ThemeToggle.jsx`: ☀️/🌙 toggle button, reads/writes `agentboss_theme` localStorage
- `Navbar.jsx`: ThemeToggle integrated next to LanguageSwitch
- `index.css`: `.theme-toggle` button styles

## Verification

- [ ] Theme toggle button visible in Navbar
- [ ] Clicking toggles between light and dark theme
- [ ] Theme persists after page refresh
- [ ] No flash on page load (inline script runs before JS bundle)
- [ ] All components adapt to theme variables
- [ ] `npm test` passes

Closes #46.